### PR TITLE
Add support for riscv64 to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -853,7 +853,11 @@ else
 ifeq ($(findstring powerpc,$(shell uname -p)),powerpc)
 DESTCPU ?= ppc64
 else
+ifeq ($(findstring riscv64,$(shell uname -p)),riscv64)
+DESTCPU ?= riscv64
+else
 DESTCPU ?= x86
+endif
 endif
 endif
 endif
@@ -884,7 +888,11 @@ else
 ifeq ($(DESTCPU),s390x)
 ARCH=s390x
 else
+ifeq ($(DESTCPU),riscv64)
+ARCH=riscv64
+else
 ARCH=x86
+endif
 endif
 endif
 endif


### PR DESCRIPTION
Added changes to the Makefile to allow building tarballs without separate commands or scripts.

Steps to build:

1. Install bootlin toolchain from https://toolchains.bootlin.com/releases_riscv64.html into `/opt/riscv64--glibc--bleeding-edge-2020.02-2`.
2. Export path: `export PATH=/opt/riscv64--glibc--bleeding-edge-2020.02-2/bin:$PATH`
3. Link libraries with: `sudo ln -s /opt/riscv64--glibc--bleeding-edge-2020.02-2/riscv64-buildroot-linux-gnu/sysroot/lib/ld-linux-riscv64-lp64.so.1 /lib`

Then build the tarballs and binary with:

```sh
make binary DESTCPU=riscv64 CC=riscv64-buildroot-linux-gnu-gcc CXX=riscv64-buildroot-linux-gnu-g++ CC_host=gcc CXX_host=g++ CONFIG_FLAGS="--openssl-no-asm --build-v8-with-gn --cross-compiling" -j`nproc`
```

It should work with other toolchains, just adjusting the link, exports and compiler triplets in the make command.